### PR TITLE
expose CommitDate, too

### DIFF
--- a/gitmap.go
+++ b/gitmap.go
@@ -45,6 +45,7 @@ type GitInfo struct {
 	AuthorName      string    `json:"authorName"`      // The author name, respecting .mailmap
 	AuthorEmail     string    `json:"authorEmail"`     // The author email address, respecting .mailmap
 	AuthorDate      time.Time `json:"authorDate"`      // The author date
+	CommitDate      time.Time `json:"commitDate"`      // The commit date
 }
 
 // Map creates a GitRepo with a file map from the given repository path and revision.
@@ -69,7 +70,7 @@ func Map(repository, revision string) (*GitRepo, error) {
 	topLevelPath := filepath.ToSlash(filepath.Join(absRepoPath, cdUp))
 
 	gitLogArgs := strings.Fields(fmt.Sprintf(
-		`--name-only --no-merges --format=format:%%x1e%%H%%x1f%%h%%x1f%%s%%x1f%%aN%%x1f%%aE%%x1f%%ai %s`,
+		`--name-only --no-merges --format=format:%%x1e%%H%%x1f%%h%%x1f%%s%%x1f%%aN%%x1f%%aE%%x1f%%ai%%x1f%%ci %s`,
 		revision,
 	))
 
@@ -126,7 +127,10 @@ func git(args ...string) ([]byte, error) {
 func toGitInfo(entry string) (*GitInfo, error) {
 	items := strings.Split(entry, "\x1f")
 	authorDate, err := time.Parse("2006-01-02 15:04:05 -0700", items[5])
-
+	if err != nil {
+		return nil, err
+	}
+	commitDate, err := time.Parse("2006-01-02 15:04:05 -0700", items[6])
 	if err != nil {
 		return nil, err
 	}
@@ -138,6 +142,7 @@ func toGitInfo(entry string) (*GitInfo, error) {
 		AuthorName:      items[3],
 		AuthorEmail:     items[4],
 		AuthorDate:      authorDate,
+		CommitDate:      commitDate,
 	}, nil
 }
 

--- a/gitmap_test.go
+++ b/gitmap_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	revision   = "4d9ad733fa40310607ebe9f700d59dcac93ace89"
+	revision   = "e7c73e5e4b576d4c6d47c382e93ddf26b935e229"
 	repository string
 )
 
@@ -37,29 +37,40 @@ func TestMap(t *testing.T) {
 
 	gm = gr.Files
 
-	if len(gm) != 9 {
+	if len(gm) != 11 {
 		t.Fatalf("Wrong number of files, got %d, expected %d", len(gm), 9)
 	}
 
 	assertFile(t, gm,
 		"testfiles/d1/d1.txt",
-		"4d9ad73",
-		"4d9ad733fa40310607ebe9f700d59dcac93ace89",
+		"39120eb",
+		"39120eb28a2f8a0312f9b45f91b6abb687b7fd3c",
+		"2016-07-20",
 		"2016-07-20",
 	)
 
 	assertFile(t, gm,
 		"testfiles/d2/d2.txt",
-		"9d1dc47",
-		"9d1dc478eef267829831226d913a3ca249c489d4",
-		"2016-07-19",
+		"39120eb",
+		"39120eb28a2f8a0312f9b45f91b6abb687b7fd3c",
+		"2016-07-20",
+		"2016-07-20",
+	)
+
+	assertFile(t, gm,
+		"testfiles/amended.txt",
+		"e7c73e5",
+		"e7c73e5e4b576d4c6d47c382e93ddf26b935e229",
+		"2019-05-23",
+		"2019-05-25",
 	)
 
 	assertFile(t, gm,
 		"README.md",
-		"866cbcc",
-		"866cbccdab588b9908887ffd3b4f2667e94090c3",
-		"2016-07-20",
+		"0b830e4",
+		"0b830e458446fdb774b1688af9b402acf388d6ab",
+		"2016-07-22",
+		"2016-07-22",
 	)
 }
 
@@ -69,7 +80,8 @@ func assertFile(
 	filename,
 	expectedAbbreviatedHash,
 	expectedHash,
-	expectedDate string) {
+	expectedAuthorDate,
+	expectedCommitDate string) {
 
 	var (
 		gi *GitInfo
@@ -84,12 +96,20 @@ func assertFile(
 		t.Error("Invalid tree hash, file", filename, "abbreviated:", gi.AbbreviatedHash, "full:", gi.Hash, gi.Subject)
 	}
 
-	if gi.AuthorName != "Bjørn Erik Pedersen" || gi.AuthorEmail != "bjorn.erik.pedersen@gmail.com" {
+	if gi.AuthorName != "Bjørn Erik Pedersen" && gi.AuthorName != "Michael Stapelberg" {
 		t.Error("These commits are mine! Got", gi.AuthorName, "and", gi.AuthorEmail)
 	}
 
-	if gi.AuthorDate.Format("2006-01-02") != expectedDate {
-		t.Error("Invalid date:", gi.AuthorDate)
+	if gi.AuthorEmail != "bjorn.erik.pedersen@gmail.com" && gi.AuthorEmail != "stapelberg@google.com" {
+		t.Error("These commits are mine! Got", gi.AuthorName, "and", gi.AuthorEmail)
+	}
+
+	if got, want := gi.AuthorDate.Format("2006-01-02"), expectedAuthorDate; got != want {
+		t.Errorf("%s: unexpected author date: got %v, want %v", filename, got, want)
+	}
+
+	if got, want := gi.CommitDate.Format("2006-01-02"), expectedCommitDate; got != want {
+		t.Errorf("%s: unexpected commit date: got %v, want %v", filename, got, want)
 	}
 }
 
@@ -154,7 +174,7 @@ func TestEncodeJSON(t *testing.T) {
 
 	s := string(b)
 
-	if s != `{"hash":"866cbccdab588b9908887ffd3b4f2667e94090c3","abbreviatedHash":"866cbcc","subject":"Add codecov to Travis config","authorName":"Bjørn Erik Pedersen","authorEmail":"bjorn.erik.pedersen@gmail.com","authorDate":"2016-07-20T02:22:23+02:00","commitDate":"2016-07-20T02:42:36+02:00"}` {
+	if s != `{"hash":"0b830e458446fdb774b1688af9b402acf388d6ab","abbreviatedHash":"0b830e4","subject":"Add some more to README","authorName":"Bjørn Erik Pedersen","authorEmail":"bjorn.erik.pedersen@gmail.com","authorDate":"2016-07-22T21:40:27+02:00","commitDate":"2016-07-22T21:40:27+02:00"}` {
 		t.Errorf("JSON marshal error: \n%s", s)
 	}
 }

--- a/gitmap_test.go
+++ b/gitmap_test.go
@@ -154,7 +154,7 @@ func TestEncodeJSON(t *testing.T) {
 
 	s := string(b)
 
-	if s != `{"hash":"866cbccdab588b9908887ffd3b4f2667e94090c3","abbreviatedHash":"866cbcc","subject":"Add codecov to Travis config","authorName":"Bjørn Erik Pedersen","authorEmail":"bjorn.erik.pedersen@gmail.com","authorDate":"2016-07-20T02:22:23+02:00"}` {
+	if s != `{"hash":"866cbccdab588b9908887ffd3b4f2667e94090c3","abbreviatedHash":"866cbcc","subject":"Add codecov to Travis config","authorName":"Bjørn Erik Pedersen","authorEmail":"bjorn.erik.pedersen@gmail.com","authorDate":"2016-07-20T02:22:23+02:00","commitDate":"2016-07-20T02:42:36+02:00"}` {
 		t.Errorf("JSON marshal error: \n%s", s)
 	}
 }

--- a/testfiles/amended.txt
+++ b/testfiles/amended.txt
@@ -1,0 +1,1 @@
+different author/commit date


### PR DESCRIPTION
When amending commits, the CommitDate gets updated, but AuthorDate does not.

For my website, I would like to use CommitDate as “last updated” instead of
AuthorDate.