### PR TITLE
Fix for error "inexact rename detection was skipped due to too many f…

### DIFF
--- a/gitmap.go
+++ b/gitmap.go
@@ -74,8 +74,7 @@ func Map(repository, revision string) (*GitRepo, error) {
 		revision,
 	))
 
-	gitLogArgs = append([]string{"-C", repository, "log"}, gitLogArgs...)
-
+	gitLogArgs = append([]string{"-c", "diff.renames=0", "-C", repository, "log"}, gitLogArgs...)	
 	out, err = git(gitLogArgs...)
 
 	if err != nil {


### PR DESCRIPTION
…iles"

Failed to read Git log: parsing time "2010-01-21 17:03:44 +0000warning: inexact rename detection was skipped due to too many files.

See: https://github.com/gohugoio/hugo/issues/6313