### PR TITLE
Fixes issues in go.mod and works around a go mod tidy limitation

### DIFF
--- a/gitmap_test.go
+++ b/gitmap_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	revision   = "57701f7ce5817fb9886c95c98a22d8c7dbb39119"
+	revision   = "45938ec0e55c26cd0e949f6de77abc210255926c"
 	repository string
 )
 
@@ -37,8 +37,8 @@ func TestMap(t *testing.T) {
 
 	gm = gr.Files
 
-	if len(gm) != 12 {
-		t.Fatalf("Wrong number of files, got %d, expected %d", len(gm), 12)
+	if len(gm) != 13 {
+		t.Fatalf("Wrong number of files, got %d, expected %d", len(gm), 13)
 	}
 
 	assertFile(t, gm,
@@ -75,8 +75,8 @@ func TestMap(t *testing.T) {
 
 	assertFile(t, gm,
 		"testfiles/emoji📚.txt",
-		"57701f7",
-		"57701f7ce5817fb9886c95c98a22d8c7dbb39119",
+		"45938ec",
+		"45938ec0e55c26cd0e949f6de77abc210255926c",
 		"2022-04-22",
 		"2022-04-22",
 	)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module gitmap
+module github.com/bep/gitmap
 
 go 1.18


### PR DESCRIPTION
- I had to update revision and the commit hashes in `gitmap_test.go` because the commit I used disappeared during the PR merge. The new commit hash is part of bep/gitmap's history so it should be stable now.
- I had to bump up 12 to 13 because of testfiles/go.mod.
- I updated go.mod based on [jmooring](https://github.com/jmooring)'s suggestion (it's the first time I touch a go.mod file, sorry).

Tests run cleanly with the latest version of this PR:

```
19:24:47 gitmap go clean -testcache && go test -v github.com/bep/gitmap                                                                         hugo9810b !
=== RUN   TestMap
--- PASS: TestMap (0.02s)
=== RUN   TestActiveRevision
--- PASS: TestActiveRevision (0.02s)
=== RUN   TestGitExecutableNotFound
--- PASS: TestGitExecutableNotFound (0.00s)
=== RUN   TestEncodeJSON
--- PASS: TestEncodeJSON (0.02s)
=== RUN   TestGitRevisionNotFound
--- PASS: TestGitRevisionNotFound (0.02s)
=== RUN   TestGitRepoNotFound
--- PASS: TestGitRepoNotFound (0.01s)
=== RUN   TestTopLevelAbsPath
--- PASS: TestTopLevelAbsPath (0.02s)
PASS
ok      github.com/bep/gitmap   0.256s
19:24:57 gitmap
```