### PR TITLE
Expose commit body

### DIFF
--- a/gitmap_test.go
+++ b/gitmap_test.go
@@ -113,6 +113,38 @@ func assertFile(
 	}
 }
 
+func TestCommitMessage(t *testing.T) {
+	var (
+		gm  GitMap
+		gr  *GitRepo
+		err error
+	)
+
+	if gr, err = Map(repository, "HEAD"); err != nil {
+		t.Fatal(err)
+	}
+
+	gm = gr.Files
+
+	// Test Subject and Body
+	var (
+		gi *GitInfo
+		ok bool
+	)
+	filename := "testfiles/d1/d1.txt"
+	if gi, ok = gm[filename]; !ok {
+		t.Fatal(filename)
+	}
+
+	if gi.Subject != "Change the test files" {
+		t.Error("Incorrect subject. Got", gi.Subject)
+	}
+
+	if gi.Body != "To trigger a test variant." {
+		t.Error("Incorrect commit body. Got", gi.Body)
+	}
+}
+
 func TestActiveRevision(t *testing.T) {
 	var (
 		gm  GitMap
@@ -172,7 +204,7 @@ func TestEncodeJSON(t *testing.T) {
 
 	s := string(b)
 
-	if s != `{"hash":"0b830e458446fdb774b1688af9b402acf388d6ab","abbreviatedHash":"0b830e4","subject":"Add some more to README","authorName":"Bjørn Erik Pedersen","authorEmail":"bjorn.erik.pedersen@gmail.com","authorDate":"2016-07-22T21:40:27+02:00","commitDate":"2016-07-22T21:40:27+02:00"}` {
+	if s != `{"hash":"0b830e458446fdb774b1688af9b402acf388d6ab","abbreviatedHash":"0b830e4","subject":"Add some more to README","authorName":"Bjørn Erik Pedersen","authorEmail":"bjorn.erik.pedersen@gmail.com","authorDate":"2016-07-22T21:40:27+02:00","commitDate":"2016-07-22T21:40:27+02:00","body":""}` {
 		t.Errorf("JSON marshal error: \n%s", s)
 	}
 }

--- a/gitmap_test.go
+++ b/gitmap_test.go
@@ -126,23 +126,52 @@ func TestCommitMessage(t *testing.T) {
 
 	gm = gr.Files
 
-	// Test Subject and Body
+	assertMessage(
+		t, gm,
+		"testfiles/d1/d1.txt",
+		"Change the test files",
+		"To trigger a test variant.",
+	)
+
+	assertMessage(
+		t, gm,
+		"testfiles/r3.txt",
+		"Add test file for commit body",
+		"- This is a multi-line\n- commit body",
+	)
+
+	assertMessage(
+		t, gm,
+		"testfiles/amended.txt",
+		"Add testfile with different author/commit date",
+		"",
+	)
+}
+
+func assertMessage(
+	t *testing.T,
+	gm GitMap,
+	filename,
+	expectedSubject,
+	expectedBody string,
+) {
 	var (
 		gi *GitInfo
 		ok bool
 	)
-	filename := "testfiles/d1/d1.txt"
+
 	if gi, ok = gm[filename]; !ok {
 		t.Fatal(filename)
 	}
 
-	if gi.Subject != "Change the test files" {
-		t.Error("Incorrect subject. Got", gi.Subject)
+	if gi.Subject != expectedSubject {
+		t.Error("Incorrect commit subject. Got", gi.Subject)
 	}
 
-	if gi.Body != "To trigger a test variant." {
+	if gi.Body != expectedBody {
 		t.Error("Incorrect commit body. Got", gi.Body)
 	}
+
 }
 
 func TestActiveRevision(t *testing.T) {


### PR DESCRIPTION
This PR is in reference to https://github.com/gohugoio/hugo/issues/10905 to make the full commit message (body) visible in the GitInfo.

The changes I've done in the three commits are outlined below:
- Modified the `git log` command to include `%b` in the format to show the commit message body.
- Changed the GitInfo type stryct to include `Body`.
- `\x1d` is used to separate the GitInfo items from file names, instead of new lines as done previously. This is because a commit message body can have new lines. File names are then split by new lines this results in a new array being created.
- The commit message body is trimmed for empty spaces and new lines in the toGitInfo function.
- Commit messages with no body have an empty string appended to the end of the array in the toGitInfo function so every commit will have either the Body if available or an empty string.
- Added `TestCommitMessage` and `AssertMessage` functions to assert the Subject and Body of commit messages for three different files. One with a Subject and no Body, one with a Subject and single line Body and one with a Subject and multi-line body.

I'm not very familar with Golang to may have made simple errors, please feel free to point out any improvements that could be done.

Thanks!