### PR TITLE
Ignore environment variables when executing git command

### DIFF
--- a/gitmap.go
+++ b/gitmap.go
@@ -49,18 +49,23 @@ type GitInfo struct {
 	Body            string    `json:"body"`            // The commit message body
 }
 
-// Map creates a GitRepo with a file map from the given repository path and revision.
-// Use blank or HEAD as revision for the currently active revision.
-func Map(repository, revision string) (*GitRepo, error) {
+// Options for the Map function
+type Options struct {
+	Repository string // Path to the repository to map
+	Revision   string // Use blank or HEAD for the currently active revision
+}
+
+// Map creates a GitRepo with a file map from the given options.
+func Map(opts Options) (*GitRepo, error) {
 	m := make(GitMap)
 
 	// First get the top level repo path
-	absRepoPath, err := filepath.Abs(repository)
+	absRepoPath, err := filepath.Abs(opts.Repository)
 	if err != nil {
 		return nil, err
 	}
 
-	out, err := git("-C", repository, "rev-parse", "--show-cdup")
+	out, err := git("-C", opts.Repository, "rev-parse", "--show-cdup")
 	if err != nil {
 		return nil, err
 	}
@@ -70,10 +75,10 @@ func Map(repository, revision string) (*GitRepo, error) {
 
 	gitLogArgs := strings.Fields(fmt.Sprintf(
 		`--name-only --no-merges --format=format:%%x1e%%H%%x1f%%h%%x1f%%s%%x1f%%aN%%x1f%%aE%%x1f%%ai%%x1f%%ci%%x1f%%b%%x1d %s`,
-		revision,
+		opts.Revision,
 	))
 
-	gitLogArgs = append([]string{"-c", "diff.renames=0", "-c", "log.showSignature=0", "-C", repository, "log"}, gitLogArgs...)
+	gitLogArgs = append([]string{"-c", "diff.renames=0", "-c", "log.showSignature=0", "-C", opts.Repository, "log"}, gitLogArgs...)
 	out, err = git(gitLogArgs...)
 	if err != nil {
 		return nil, err

--- a/gitmap.go
+++ b/gitmap.go
@@ -51,12 +51,19 @@ type GitInfo struct {
 
 // Options for the Map function
 type Options struct {
-	Repository string // Path to the repository to map
-	Revision   string // Use blank or HEAD for the currently active revision
+	Repository        string // Path to the repository to map
+	Revision          string // Use blank or HEAD for the currently active revision
+	GetGitCommandFunc func(args ...string) *exec.Cmd
 }
 
 // Map creates a GitRepo with a file map from the given options.
 func Map(opts Options) (*GitRepo, error) {
+	if opts.GetGitCommandFunc == nil {
+		opts.GetGitCommandFunc = func(args ...string) *exec.Cmd {
+			return exec.Command(gitExec, args...)
+		}
+	}
+
 	m := make(GitMap)
 
 	// First get the top level repo path
@@ -65,7 +72,7 @@ func Map(opts Options) (*GitRepo, error) {
 		return nil, err
 	}
 
-	out, err := git("-C", opts.Repository, "rev-parse", "--show-cdup")
+	out, err := git(opts, "-C", opts.Repository, "rev-parse", "--show-cdup")
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +86,7 @@ func Map(opts Options) (*GitRepo, error) {
 	))
 
 	gitLogArgs = append([]string{"-c", "diff.renames=0", "-c", "log.showSignature=0", "-C", opts.Repository, "log"}, gitLogArgs...)
-	out, err = git(gitLogArgs...)
+	out, err = git(opts, gitLogArgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -109,8 +116,8 @@ func Map(opts Options) (*GitRepo, error) {
 	return &GitRepo{Files: m, TopLevelAbsPath: topLevelPath}, nil
 }
 
-func git(args ...string) ([]byte, error) {
-	out, err := exec.Command(gitExec, args...).CombinedOutput()
+func git(opts Options, args ...string) ([]byte, error) {
+	out, err := opts.GetGitCommandFunc(args...).CombinedOutput()
 	if err != nil {
 		if ee, ok := err.(*exec.Error); ok {
 			if ee.Err == exec.ErrNotFound {

--- a/gitmap_test.go
+++ b/gitmap_test.go
@@ -31,7 +31,7 @@ func TestMap(t *testing.T) {
 		err error
 	)
 
-	if gr, err = Map(repository, revision); err != nil {
+	if gr, err = Map(Options{Repository: repository, Revision: revision}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -120,7 +120,7 @@ func TestCommitMessage(t *testing.T) {
 		err error
 	)
 
-	if gr, err = Map(repository, "HEAD"); err != nil {
+	if gr, err = Map(Options{Repository: repository, Revision: "HEAD"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -182,7 +182,7 @@ func TestActiveRevision(t *testing.T) {
 		err error
 	)
 
-	if gr, err = Map(repository, "HEAD"); err != nil {
+	if gr, err = Map(Options{Repository: repository, Revision: "HEAD"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -200,7 +200,7 @@ func TestActiveRevision(t *testing.T) {
 func TestGitExecutableNotFound(t *testing.T) {
 	defer initDefaults()
 	gitExec = "thisShouldHopefullyNotExistOnPath"
-	gi, err := Map(repository, revision)
+	gi, err := Map(Options{Repository: repository, Revision: revision})
 
 	if err != ErrGitNotFound || gi != nil {
 		t.Fatal("Invalid error handling")
@@ -217,7 +217,7 @@ func TestEncodeJSON(t *testing.T) {
 		filename = "README.md"
 	)
 
-	if gr, err = Map(repository, revision); err != nil {
+	if gr, err = Map(Options{Repository: repository, Revision: revision}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -240,7 +240,7 @@ func TestEncodeJSON(t *testing.T) {
 }
 
 func TestGitRevisionNotFound(t *testing.T) {
-	gi, err := Map(repository, "adfasdfasdf")
+	gi, err := Map(Options{Repository: repository, Revision: "adfasdfasdf"})
 
 	// TODO(bep) improve error handling.
 	if err == nil || gi != nil {
@@ -249,7 +249,7 @@ func TestGitRevisionNotFound(t *testing.T) {
 }
 
 func TestGitRepoNotFound(t *testing.T) {
-	gi, err := Map("adfasdfasdf", revision)
+	gi, err := Map(Options{Repository: "adfasdfasdf", Revision: revision})
 
 	// TODO(bep) improve error handling.
 	if err == nil || gi != nil {
@@ -263,7 +263,7 @@ func TestTopLevelAbsPath(t *testing.T) {
 		err error
 	)
 
-	if gr, err = Map(repository, revision); err != nil {
+	if gr, err = Map(Options{Repository: repository, Revision: revision}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -276,7 +276,7 @@ func TestTopLevelAbsPath(t *testing.T) {
 
 func BenchmarkMap(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, err := Map(repository, revision)
+		_, err := Map(Options{Repository: repository, Revision: revision})
 		if err != nil {
 			b.Fatalf("Got error: %s", err)
 		}


### PR DESCRIPTION
We encountered the issue gohugoio/hugo#8627 seemingly random, until we realized that the environment variable `GIT_TRACE` was enabled for debugging.
The parsing logic does not handle the additional output very well and therefore panics with the "index out of range" error.

The simplest solution would be to ignore all environment variables.
However, I'm not absolutely sure that this has no unintended side-effects.